### PR TITLE
Use tab pages count instead of task ID for tab name.   

### DIFF
--- a/LiteDB.Studio/Forms/MainForm.cs
+++ b/LiteDB.Studio/Forms/MainForm.cs
@@ -199,7 +199,7 @@ namespace LiteDB.Studio
 
             task.Id = task.Thread.ManagedThreadId;
 
-            tab.Text = tab.Name = task.Id.ToString();
+            tab.Text = tab.Name = tabSql.TabPages.Count.ToString();
             tab.Tag = task;
 
             if (tabSql.SelectedTab != tab)


### PR DESCRIPTION
Checked the use of tab.Text and tab.Name and it seems that no conditionally logic is used for these properties.   tab.Name seems to be used only for visual identification of each tab to the user.

Switching tabs still maintains the activeTask switching mechanism.   