### PR TITLE
Remove LiteDb.csproj and reference it from Nuget LiteDb v5.0.17.0 + TargetFramework bump to 4.8

### DIFF
--- a/LiteDB.Studio.sln
+++ b/LiteDB.Studio.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Studio", "LiteDB.Studio\LiteDB.Studio.csproj", "{0002E0FF-C91F-4B8B-B29B-2A477E184408}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiteDB", "LiteDB\LiteDB\LiteDB.csproj", "{70E32FF1-6E08-4BF0-9C99-33E1F3711DD7}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{0002E0FF-C91F-4B8B-B29B-2A477E184408}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0002E0FF-C91F-4B8B-B29B-2A477E184408}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0002E0FF-C91F-4B8B-B29B-2A477E184408}.Release|Any CPU.Build.0 = Release|Any CPU
-		{70E32FF1-6E08-4BF0-9C99-33E1F3711DD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{70E32FF1-6E08-4BF0-9C99-33E1F3711DD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{70E32FF1-6E08-4BF0-9C99-33E1F3711DD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{70E32FF1-6E08-4BF0-9C99-33E1F3711DD7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LiteDB.Studio/Forms/MainForm.cs
+++ b/LiteDB.Studio/Forms/MainForm.cs
@@ -70,7 +70,7 @@ namespace LiteDB.Studio
 
             // set assembly version on window title
             this.Text += $" (LiteDB.Studio: v{typeof(MainForm).Assembly.GetName().Version.ToString()}";
-            this.Text += $" - LiteDB v5.0.15)"; // how do I get this version? (ILMerge ommits LiteDB assembly)
+            this.Text += $" - LiteDB v5.0.17)"; // how do I get this version? (ILMerge ommits LiteDB assembly)
 
             // load last db
 

--- a/LiteDB.Studio/LiteDB.Studio.csproj
+++ b/LiteDB.Studio/LiteDB.Studio.csproj
@@ -10,7 +10,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>LiteDB.Studio</RootNamespace>
     <AssemblyName>LiteDB.Studio</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
@@ -40,6 +40,9 @@
     <ApplicationIcon>LiteDB.Studio.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="LiteDB, Version=5.0.17.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
+      <HintPath>..\packages\LiteDB.5.0.17\lib\net45\LiteDB.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -351,12 +354,6 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\LiteDB\LiteDB\LiteDB.csproj">
-      <Project>{70e32ff1-6e08-4bf0-9c99-33e1f3711dd7}</Project>
-      <Name>LiteDB</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/LiteDB.Studio/packages.config
+++ b/LiteDB.Studio/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="3.0.41" targetFramework="net472" />
-  <package id="LiteDB" version="5.0.11" targetFramework="net472" />
+  <package id="LiteDB" version="5.0.17" targetFramework="net472" />
   <package id="MSBuild.ILMerge.Task" version="1.1.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This PR will introduce following changes:

- Remove LiteDb.csproj from LiteDb.Studio.sln
- Update TargetFramework to .NetFramework 4.8
- Reintroduce LiteDb usage via latest 5.0.17.0 version of nuget packge.

I think that removing LiteDb.csproj from the solution will remove confusion as for why we have project that is as well re-added from NuGet. This as well updates LiteDb.Studio to use latest version of LiteDb and resolve reference posible conflicts that could araise after nuget update.  