### PR TITLE
fixed bug while clicking 'Connect' button w/o properly value in 'filename' field

### DIFF
--- a/LiteDB.Studio/Forms/ConnectionForm.cs
+++ b/LiteDB.Studio/Forms/ConnectionForm.cs
@@ -51,6 +51,12 @@ namespace LiteDB.Studio.Forms
 
         private void BtnConnect_Click(object sender, EventArgs e)
         {
+            if (!AppSettingsManager.IsDbExist(txtFilename.Text))
+            {
+                MessageBox.Show($"Field {groupBox2.Text} should contains valid path to database file, please check it out.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
             this.ConnectionString.Connection =
                 radModeDirect.Checked ? ConnectionType.Direct :
                 radModeShared.Checked ? ConnectionType.Shared : ConnectionType.Direct;


### PR DESCRIPTION
As I see, there is no checks about correct value in 'filename' field.
In this case I can get unhandled exception if I click "Connect" button with empty string in this field
![image](https://github.com/mbdavid/LiteDB.Studio/assets/5287406/83a14b31-c0c2-4c78-acbf-7ec0523e0962)
