### PR TITLE
Fix grid textfield not displaying values longer than 633 characters

### DIFF
--- a/LiteDB.Studio/Classes/UIExtensions.cs
+++ b/LiteDB.Studio/Classes/UIExtensions.cs
@@ -43,9 +43,9 @@ namespace LiteDB.Studio
                         grd.Columns.Add(key, key);
 
                         col = grd.Columns[key];
-                        col.AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
-
-                        col.ReadOnly = key == "_id";
+                        //col.AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+						col.Width = 150;
+						col.ReadOnly = key == "_id";
                     }
                 }
 
@@ -58,7 +58,9 @@ namespace LiteDB.Studio
                     var cell = row.Cells[col.Index];
 
                     cell.Style.BackColor = Color.White;
-                    cell.Value = value.IsDocument ? value[key] : value;
+                    var bson = value.IsDocument ? value[key] : value;
+                    cell.Value = bson;
+                    cell.Tag = bson;
 
                     row.ReadOnly = key == "_id";
                 }

--- a/LiteDB.Studio/Forms/MainForm.cs
+++ b/LiteDB.Studio/Forms/MainForm.cs
@@ -815,6 +815,11 @@ namespace LiteDB.Studio
                     e.Value = JsonSerializer.Serialize(value);
                     break;
             }
+
+            if (e.Value is string str && str.Length > 150)
+            {
+                e.Value = str.Substring(0, 150) + "...";
+            }
         }
 
         private void LoadLastDbChecked_Changed(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Data grid columns now display with fixed width sizing (150px) instead of dynamically adjusting based on content, providing consistent and predictable layout across data tables
  * Long text values in grid cells are now truncated to 150 characters followed by ellipsis, improving visual clarity and preventing layout disruption caused by extended data entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->